### PR TITLE
OneOf enum value should not be retrieved with form values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file. The changes are grouped by the date (ISO-8601) and the package version they have been added to. The `Unreleased` section keeps track of upcoming changes.
 
+## [4.0.0] (2021-05-21)
+### Bug Fixes
+- OneOf: XOf Enum values should not be sent when retrieving form values. These were added for JSF to display the data as a dropdown but is not part of the schema specification. All child properties should have unique key names so that the matching OneOf subschema can be determined.
+
 ## [3.1.1] (2021-05-13)
 ### Bug Fixes
 - Empty array should not be defaulted to empty string

--- a/projects/jsf-launcher/src/app/dataV2.json
+++ b/projects/jsf-launcher/src/app/dataV2.json
@@ -35,22 +35,16 @@
   },
   "dropdownsWithChildren": {
     "dropdownWithChildren1": {
-      "option1": {
-        "child1": "TEST TEXT",
-        "child2": ""
-      }
+      "opt1Child1": "TEST TEXT",
+      "opt1Child2": ""
     },
     "dropdownWithChildren1WithDefault": {
-      "option2": {
-        "child1": "",
-        "child2": "TEST TEXT"
-      }
+      "opt2Child1": "",
+      "opt2Child2": "TEST TEXT"
     },
     "hiddenDropdownWithChildren": {
-      "option2": {
-        "child1": "",
-        "child2": "default value"
-      }
+      "opt2Child1": "",
+      "opt2Child2": "default value"
     }
   },
   "textInputs": {
@@ -74,16 +68,12 @@
     },
     "dropdownsChildrenII": {
       "moreDropdowns": {
-        "dd1": {
-          "child1": "TEST TEXT",
-          "child2": "HELLO"
-        }
+        "child1": "TEST TEXT",
+        "child2": "HELLO"
       },
       "moreDropdownsDefault": {
-        "op1": {
-          "ch1": "FGIEQGFIEQGIREWGI",
-          "ch2": "TEST TEXT"
-        }
+        "ch1": "FGIEQGFIEQGIREWGI",
+        "ch2": "TEST TEXT"
       }
     },
     "integerInputs": {

--- a/projects/jsf-launcher/src/app/schemaV2.json
+++ b/projects/jsf-launcher/src/app/schemaV2.json
@@ -361,12 +361,15 @@
               "type": "object",
               "name": "Option 1",
               "key": "option1",
+              "required": [
+                "opt1Child1"
+              ],
               "properties": {
-                "child1": {
+                "opt1Child1": {
                   "type": "string",
                   "name": "Child 1 of Option 1"
                 },
-                "child2": {
+                "opt1Child2": {
                   "type": "string",
                   "name": "Child 2 of Option 1"
                 }
@@ -377,14 +380,14 @@
               "name": "Option 2",
               "key": "option2",
               "required": [
-                "child2"
+                "opt2Child2"
               ],
               "properties": {
-                "child1": {
+                "opt2Child1": {
                   "type": "string",
                   "name": "Child 1 of Option 2"
                 },
-                "child2": {
+                "opt2Child2": {
                   "type": "string",
                   "name": "Child 2 of Option 2"
                 }
@@ -401,12 +404,15 @@
               "type": "object",
               "name": "Option 1",
               "key": "option1",
+              "required": [
+                "opt1Child2"
+              ],
               "properties": {
-                "child1": {
+                "opt1Child1": {
                   "type": "string",
                   "name": "Child 1 of Option 1"
                 },
-                "child2": {
+                "opt1Child2": {
                   "type": "string",
                   "name": "Child 2 of Option 1"
                 }
@@ -417,14 +423,14 @@
               "name": "Option 2",
               "key": "option2",
               "required": [
-                "child2"
+                "opt2Child2"
               ],
               "properties": {
-                "child1": {
+                "opt2Child1": {
                   "type": "string",
                   "name": "Child 1 of Option 2"
                 },
-                "child2": {
+                "opt2Child2": {
                   "type": "string",
                   "name": "Child 2 of Option 2"
                 }
@@ -442,12 +448,15 @@
               "type": "object",
               "name": "Option 1",
               "key": "option1",
+              "required": [
+                "opt1Child2"
+              ],
               "properties": {
-                "child1": {
+                "opt1Child1": {
                   "type": "string",
                   "name": "Child 1 of Option 1"
                 },
-                "child2": {
+                "opt1Child2": {
                   "type": "string",
                   "name": "Child 2 of Option 1"
                 }
@@ -458,14 +467,14 @@
               "name": "Option 2",
               "key": "option2",
               "required": [
-                "child2"
+                "opt2Child2"
               ],
               "properties": {
-                "child1": {
+                "opt2Child1": {
                   "type": "string",
                   "name": "Child 1 of Option 2"
                 },
-                "child2": {
+                "opt2Child2": {
                   "type": "string",
                   "name": "Child 2 of Option 2",
                   "default": "default value"
@@ -484,12 +493,15 @@
               "type": "object",
               "name": "Option 1",
               "key": "option1",
+              "required": [
+                "opt1Child2"
+              ],
               "properties": {
-                "child1": {
+                "opt1Child1": {
                   "type": "string",
                   "name": "Child 1 of Option 1"
                 },
-                "child2": {
+                "opt1Child2": {
                   "type": "string",
                   "name": "Child 2 of Option 1"
                 }
@@ -500,14 +512,14 @@
               "name": "Option 2",
               "key": "option2",
               "required": [
-                "child2"
+                "opt2Child2"
               ],
               "properties": {
-                "child1": {
+                "opt2Child1": {
                   "type": "string",
                   "name": "Child 1 of Option 2"
                 },
-                "child2": {
+                "opt2Child2": {
                   "type": "string",
                   "name": "Child 2 of Option 2",
                   "default": "default value"
@@ -556,7 +568,7 @@
               "dropdownsWithChildren.dropdownWithChildren1.option1",
               "dropdownsWithChildren.dropdownWithChildren1WithDefault",
               "dropdownsWithChildren.dropdownWithChildren1WithDefault.option1",
-              "dropdownsWithChildren.dropdownWithChildren1WithDefault.option1.child1",
+              "dropdownsWithChildren.dropdownWithChildren1WithDefault.option1.opt1Child1",
               "dropdownsWithChildren.dropdownWithChildren1WithDefault.option2",
               "securedTextInput",
               "securedTextInput.securedTextInput",
@@ -771,6 +783,9 @@
                   "type": "object",
                   "name": "Option 1",
                   "key": "dd1",
+                  "required": [
+                    "child1"
+                  ],
                   "properties": {
                     "child1": {
                       "type": "string",
@@ -811,12 +826,15 @@
                   "type": "object",
                   "name": "Option 1",
                   "key": "op1",
+                  "required": [
+                    "child1"
+                  ],
                   "properties": {
-                    "ch1": {
+                    "child1": {
                       "type": "string",
                       "name": "Child 1 of Option 1"
                     },
-                    "ch2": {
+                    "child2": {
                       "type": "string",
                       "name": "Child 2 of Option 1"
                     }

--- a/projects/jsf-validation/package.json
+++ b/projects/jsf-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleo/ngx-json-schema-form-validation",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "peerDependencies": {},
   "repository": {
     "type": "git",

--- a/projects/jsf/package.json
+++ b/projects/jsf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleo/ngx-json-schema-form",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/cleo/ngx-json-schema-form"

--- a/projects/jsf/src/lib/form-content/one-of/one-of-dropdown/one-of-dropdown.component.ts
+++ b/projects/jsf/src/lib/form-content/one-of/one-of-dropdown/one-of-dropdown.component.ts
@@ -30,7 +30,8 @@ export class OneOfDropdownComponent extends ContentBaseComponent implements OnIn
     if (!this.selectedKey) {
       this.formService.setVisibilityForAllConditionalChildren(this.xOfDataItem, this.formGroup, false);
     } else {
-      this.formService.showNecessaryConditionalChildren(this.xOfDataItem, this.formGroup, [ this.selectedKey]);
+      this.selectedKey = this.selectedChildDataItem.key;
+      this.formService.showNecessaryConditionalChildren(this.xOfDataItem, this.formGroup, [ this.selectedKey ]);
     }
 
     this.formService.setVisibilityForConditionalChild(this.getDropdownDataItem(), this.getDropdownFormControl(), true);
@@ -57,6 +58,7 @@ export class OneOfDropdownComponent extends ContentBaseComponent implements OnIn
   }
 
   get selectedChildDataItem(): ParentDataItem {
-    return this.xOfDataItem.items.find(item => item.key === this.selectedKey) as ParentDataItem;
+    return this.xOfDataItem.items.find(item => item.key === this.selectedKey || ((item as any).items !== undefined &&
+      (item as any).items.find(childItem => childItem.key === this.selectedKey))) as ParentDataItem;
   }
 }

--- a/projects/jsf/src/lib/form-data-item.service.spec.ts
+++ b/projects/jsf/src/lib/form-data-item.service.spec.ts
@@ -792,9 +792,7 @@ describe('FormDataItemService', () => {
         },
         [child2Key]: {
           dropdowns: {
-            [oneOfChildKey]: {
-              child1: stringInput2
-            }
+            child1: stringInput2
           }
         }
       };

--- a/projects/jsf/src/lib/form-data-item.service.ts
+++ b/projects/jsf/src/lib/form-data-item.service.ts
@@ -152,7 +152,7 @@ export class FormDataItemService {
       childPathParts.push(object.key);
       const objectValues =
         values && values[key]
-          ? values[key][object.key]
+          ? schema[XOfType.OneOf] ? values[key] : values[key][object.key]
           : {};
 
       const isHidden = isParentHidden || object.isHidden;

--- a/projects/jsf/src/lib/jsf.component.ts
+++ b/projects/jsf/src/lib/jsf.component.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
-import { AbstractControl, FormControl, FormGroup } from '@angular/forms';
+import { FormGroup } from '@angular/forms';
 
 import { NEVER } from 'rxjs';
 import { switchMap, take, takeUntil, tap } from 'rxjs/operators';
@@ -12,18 +12,19 @@ import { JSFConfig } from './jsf-config';
 import { JSFEventButton } from './jsf-event-button';
 import { JSFEventButtonTarget } from './jsf-event-button-target';
 import { JSFSchemaData } from './jsf-schema-data';
-import { FormDataItem, FormDataItemType } from './models/form-data-item';
+import { FormDataItem } from './models/form-data-item';
 import { ParentDataItem } from './models/parent-data-item';
+import { XOfEnumDataItem } from './models/xOf-enum-data-item';
 
 @Component({
   selector: 'jsf-component',
   templateUrl: './jsf.component.html',
-  styleUrls: [ './jsf.component.scss' ],
+  styleUrls: ['./jsf.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class JSFComponent extends ComponentLifeCycle implements AfterViewInit, OnInit {
-  @ViewChild(FormContentComponent, { static: true }) content: FormContentComponent;
-  @ViewChild('formRoot', { static: true }) formElement: ElementRef<HTMLFormElement>;
+  @ViewChild(FormContentComponent, {static: true}) content: FormContentComponent;
+  @ViewChild('formRoot', {static: true}) formElement: ElementRef<HTMLFormElement>;
   @Input() config: JSFConfig;
   @Input() schemaData;
   @Output() disableSubmit: EventEmitter<boolean> = new EventEmitter<boolean>();
@@ -107,7 +108,51 @@ export class JSFComponent extends ComponentLifeCycle implements AfterViewInit, O
   }
 
   getFormValues(): any {
-    return this.formService.getFormValues(this.formGroup, this.formDataItems);
+    const formValues = this.formService.getFormValues(this.formGroup, this.formDataItems);
+
+    const flattenedItems = this.flattenDataItems(this.formDataItems);
+    const xOfEnumKeys = flattenedItems.filter(item => {
+      if (item instanceof XOfEnumDataItem) {
+        return true;
+      }
+      return false;
+    }).map(item => item.key);
+    this.removeXOfEnumValues(xOfEnumKeys, formValues);
+    return formValues;
+  }
+
+  private removeXOfEnumValues(xOfEnumKeys: string[], values: any): void {
+    Object.keys(values).forEach(key => {
+      if (xOfEnumKeys.some(enumKey => enumKey === key)) {
+        const enumValue = Object.keys(values[key])[0];
+        values[key] = values[key][enumValue];
+      }
+      if (typeof values[key] === 'object' && Object.keys(values[key])) {
+        this.removeXOfEnumValues(xOfEnumKeys, values[key]);
+      }
+    });
+  }
+
+  private flattenDataItems(items: FormDataItem[]): FormDataItem[] {
+    const flattenedObject = [];
+
+    function recursiveFlattening(cur: any) {
+      if (Array.isArray(cur)) {
+        const l = cur.length;
+        for (let i = 0; i < l; i++) {
+          recursiveFlattening(cur[i]);
+        }
+      } else if (!cur.items) {
+        flattenedObject.push(cur);
+      } else {
+        for (const p of Object.keys(cur.items)) {
+          recursiveFlattening(cur.items[p]);
+        }
+      }
+    }
+
+    recursiveFlattening(items);
+    return flattenedObject;
   }
 
   /**

--- a/projects/jsf/src/lib/models/xOf-data-item.ts
+++ b/projects/jsf/src/lib/models/xOf-data-item.ts
@@ -35,6 +35,13 @@ export class XOfDataItem extends ParentDataItem {
       this.value = Object.keys(this.value)[0];
     }
 
+    if (this.value) {
+      const selectedEnum = children.find(child => child.items.find(item => item.key === this.value));
+      if (selectedEnum) {
+        this.value = selectedEnum.key;
+      }
+    }
+
     const enumDataItem = new XOfEnumDataItem(
       this.key,
       this.label,


### PR DESCRIPTION
## Description
Because OneOf is displayed as a dropdown, the selected option was being sent as part of the form values. This does not match the schema specification. A migration will be needed for any OneOf data stored prior to this release - see Breaking Changes for details.

## Breaking Changes
Any stored schema data containing OneOf release will need to be migrated to remove the dropdown/enum value. 
Example:
```
dropdown: {
    dropdownOption1: {
        child: value 
    }
}
```

Needs to be migrated to:
```
dropdown: {
    child: value
}
```
The schema definition does not need to be updated

## 3rd Party Dependency Changes
None

## Internal Tracking Number
S-24614

## PR Checklist
_All items should be done and checked before merging._
- [x] **Title:** Provide a very brief, general summary.
- [x] **Details:** Fill out the _Description_, _Breaking Changes_, _3rd Party Dependency Changes_, and _Internal Tracking Number_ sections. If there's nothing for a given section, write "None".
- [x] **Labels:** Add one or more labels.
- [x] **Run Unit Tests:** Locally run the Karma unit tests for this project before merging this PR.
- [x] **Run Lint:** Lint the project before merging this PR.
- [x] **Changelog:** If any code change in this PR will run in production, add an entry to the "Unreleased" section of the `CHANGELOG.md` file.
- [ ] **Update the Wiki:** Update the wiki with the changes for the JSF components.
