### PR TITLE
Secured fields within oneOf should not be returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file. The changes are grouped by the date (ISO-8601) and the package version they have been added to. The `Unreleased` section keeps track of upcoming changes.
 
+## [4.0.1] (2021-05-24)
+### Bug Fixes
+- Secured fields within a oneOf should not be returned. Added optional parameter to getNonSecuredValues to return the key with a null value to support oneOf
+
 ## [4.0.0] (2021-05-21)
 ### Bug Fixes
 - OneOf: XOf Enum values should not be sent when retrieving form values. These were added for JSF to display the data as a dropdown but is not part of the schema specification. All child properties should have unique key names so that the matching OneOf subschema can be determined.

--- a/projects/jsf-validation/package.json
+++ b/projects/jsf-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleo/ngx-json-schema-form-validation",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "peerDependencies": {},
   "repository": {
     "type": "git",

--- a/projects/jsf-validation/src/lib/required-schema-value-validation.service.ts
+++ b/projects/jsf-validation/src/lib/required-schema-value-validation.service.ts
@@ -1,4 +1,4 @@
-import { SchemaHelperService } from './schema-helper.service';
+import { SchemaHelperService, XOfKeys } from './schema-helper.service';
 import { SecuredSchemaValueValidationService } from './secured-schema-value-validation.service';
 
 // @dynamic
@@ -276,7 +276,7 @@ export class RequiredSchemaValueValidationService {
       xOfKeys.forEach(xOfKey => {
         if (segment.includes(xOfKey)) {
           lastGeneralXOfSegmentIdx = xOfKeys.reduce((greatestIdx: number, currentXOfKey: string) => {
-            const lastIdx = RequiredSchemaValueValidationService.getLastIndexOfXOfSegment(keySegments, currentXOfKey);
+            const lastIdx = SchemaHelperService.getLastIndexOfXOfSegment(keySegments, currentXOfKey);
             return lastIdx > greatestIdx ? lastIdx : greatestIdx;
           }, 0);
 
@@ -332,17 +332,6 @@ export class RequiredSchemaValueValidationService {
       oneOfArray.push(optionKey);
       xOfMap.set(parentPath, oneOfArray);
     }
-  }
-
-  private static getLastIndexOfXOfSegment(schemaFormattedKeySegments: string[], xOfKeyword: string): number {
-    // find index of _last_ instance of xOf key to get the most deeply nested xOf
-    // https://stackoverflow.com/a/40929530
-    // TODO: modify findIndex() to find either the oneOf key, anyOf key, or allOf key
-    const index = schemaFormattedKeySegments
-      .slice()
-      .reverse()
-      .findIndex(keySegment => keySegment.includes(xOfKeyword)); // .includes(), since schema format is an array format, ex. oneOf[0], rather than simply oneOf
-    return index >= 0 ? (schemaFormattedKeySegments.length - 1) - index : index;
   }
 
   private static getParentObjectPath(key: string): string {
@@ -414,9 +403,4 @@ class XOfMaps {
     this.allOf = new Map();
     this.anyOf = new Map();
   }
-}
-
-enum XOfKeys {
-  ONE_OF_KEY = 'oneOf',
-  ALL_OF_KEY = 'allOf'
 }

--- a/projects/jsf-validation/src/lib/schema-helper.service.ts
+++ b/projects/jsf-validation/src/lib/schema-helper.service.ts
@@ -60,6 +60,17 @@ export class SchemaHelperService {
     return flattenedObject;
   }
 
+  public static getLastIndexOfXOfSegment(schemaFormattedKeySegments: string[], xOfKeyword: string): number {
+    // find index of _last_ instance of xOf key to get the most deeply nested xOf
+    // https://stackoverflow.com/a/40929530
+    // TODO: modify findIndex() to find either the oneOf key, anyOf key, or allOf key
+    const index = schemaFormattedKeySegments
+      .slice()
+      .reverse()
+      .findIndex(keySegment => keySegment.includes(xOfKeyword)); // .includes(), since schema format is an array format, ex. oneOf[0], rather than simply oneOf
+    return index >= 0 ? (schemaFormattedKeySegments.length - 1) - index : index;
+  }
+
   /**
    * Gets a list of any existing keys that contain a keyword.
    * Example: Passing a key of 'required' will return a list of all child required[#] properties.
@@ -157,4 +168,9 @@ export class SchemaHelperService {
       }
     }
   }
+}
+
+export enum XOfKeys {
+  ONE_OF_KEY = 'oneOf',
+  ALL_OF_KEY = 'allOf'
 }

--- a/projects/jsf-validation/src/lib/secured-schema-value-validation.service.spec.ts
+++ b/projects/jsf-validation/src/lib/secured-schema-value-validation.service.spec.ts
@@ -29,77 +29,85 @@ describe('SchemaValueSecuredValidationService', () => {
   });
 
   describe('getNonSecuredValues()', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        securedTextInput: {
+          type: 'object',
+          name: 'Secured Text Inputs',
+          description: 'This section displays the functionality of the secured text inputs.',
+          properties: {
+            securedTextInput: {
+              type: 'string',
+              name: 'Required Secured Text Input',
+              helpText: 'This help text will display when you hover over the information icon',
+              tooltip: 'This tooltip will display when you hover over the label.',
+              isSecured: true
+            }
+          }
+        },
+        numberInputs: {
+          type: 'object',
+          name: 'Number Inputs',
+          description: 'This section displays number input functionality of the JSF.',
+          properties: {
+            numberInput: {
+              type: 'number',
+              name: 'Number Input',
+              helpText: 'This help text will display when you hover over the information icon',
+              tooltip: 'This tooltip will display when you hover over the label.'
+            }
+          }
+        },
+        arrayInput: {
+          type: 'array',
+          name: 'Array Input',
+          description: 'This section displays array input functionality of the JSF.',
+          items: {
+            properties: {
+              numberInput: {
+                type: 'number',
+                name: 'Number Input',
+                helpText: 'This help text will display when you hover over the information icon',
+                tooltip: 'This tooltip will display when you hover over the label.'
+              }
+            }
+          }
+        }
+      }
+    };
+
+    const values = {
+      securedTextInput: {
+        securedTextInput: 'asdf'
+      },
+      numberInputs: {
+        numberInput: 100
+      },
+      arrayInput: [{ numberInput: '100' }]
+    };
+
     it('should return an empty object if there are no values', () => {
       const result = SecuredSchemaValueValidationService.getNonSecuredValues({}, {});
       expect(Object.keys(result).length).toEqual(0);
     });
 
     it('should return all non-secured schema values', () => {
-      const schema = {
-        type: 'object',
-        properties: {
-          securedTextInput: {
-            type: 'object',
-            name: 'Secured Text Inputs',
-            description: 'This section displays the functionality of the secured text inputs.',
-            properties: {
-              securedTextInput: {
-                type: 'string',
-                name: 'Required Secured Text Input',
-                helpText: 'This help text will display when you hover over the information icon',
-                tooltip: 'This tooltip will display when you hover over the label.',
-                isSecured: true
-              }
-            }
-          },
-          numberInputs: {
-            type: 'object',
-            name: 'Number Inputs',
-            description: 'This section displays number input functionality of the JSF.',
-            properties: {
-              numberInput: {
-                type: 'number',
-                name: 'Number Input',
-                helpText: 'This help text will display when you hover over the information icon',
-                tooltip: 'This tooltip will display when you hover over the label.'
-              }
-            }
-          },
-          arrayInput: {
-            type: 'array',
-            name: 'Array Input',
-            description: 'This section displays array input functionality of the JSF.',
-            items: {
-              properties: {
-                  numberInput: {
-                  type: 'number',
-                  name: 'Number Input',
-                  helpText: 'This help text will display when you hover over the information icon',
-                  tooltip: 'This tooltip will display when you hover over the label.'
-                }
-              }
-            }
-          }
-        }
-      };
-
-      const values = {
-        securedTextInput: {
-          securedTextInput: 'asdf'
-        },
-        numberInputs: {
-          numberInput: 100
-        },
-        arrayInput: [{ numberInput: '100' }]
-      };
       const result = SecuredSchemaValueValidationService.getNonSecuredValues(values, schema);
       expect(result.securedTextInput.securedTextInput).toBeUndefined();
       expect(result.numberInputs.numberInput).toEqual(100);
       expect(result.arrayInput[0]).toEqual({ numberInput: '100'});
     });
 
+    it('should return secured values as null', () => {
+      const result = SecuredSchemaValueValidationService.getNonSecuredValues(values, schema, true);
+      expect(result.securedTextInput.securedTextInput).toBeNull();
+      expect(result.numberInputs.numberInput).toEqual(100);
+      expect(result.arrayInput[0]).toEqual({ numberInput: '100'});
+    });
+
     it('should not return secured text that returns an object', () => {
-      const schema = {
+      const nestedSchema = {
         type: 'object',
         properties: {
           securedTextInput: {
@@ -132,7 +140,7 @@ describe('SchemaValueSecuredValidationService', () => {
         }
       };
 
-      const values = {
+      const nestedValues = {
         securedTextInput: {
           securedTextInput: {
             key1: 'key1',
@@ -144,7 +152,7 @@ describe('SchemaValueSecuredValidationService', () => {
         }
       };
 
-      const result = SecuredSchemaValueValidationService.getNonSecuredValues(values, schema);
+      const result = SecuredSchemaValueValidationService.getNonSecuredValues(nestedValues, nestedSchema);
       expect(result.securedTextInput.securedTextInput).toBeUndefined();
       expect(result.numberInputs.numberInput).toEqual(100);
     });

--- a/projects/jsf-validation/src/lib/secured-schema-value-validation.service.ts
+++ b/projects/jsf-validation/src/lib/secured-schema-value-validation.service.ts
@@ -1,4 +1,4 @@
-import { SchemaHelperService } from './schema-helper.service';
+import { SchemaHelperService, XOfKeys } from './schema-helper.service';
 
 // @dynamic
 export class SecuredSchemaValueValidationService {
@@ -6,11 +6,11 @@ export class SecuredSchemaValueValidationService {
 
   public static getSecuredKeyPaths(flattenedSchema: any): string[] {
     return Object.keys(flattenedSchema)
-      .filter((keyPath) => keyPath.includes(SchemaHelperService.SECURED_KEY) && flattenedSchema[ keyPath ])
+      .filter((keyPath) => keyPath.includes(SchemaHelperService.SECURED_KEY) && flattenedSchema[keyPath])
       .map(item => SchemaHelperService.formatKeyPath(item));
   }
 
-  public static getNonSecuredValues(values: any, schema: any): any {
+  public static getNonSecuredValues(values: any, schema: any, returnNullForSecuredValues: boolean = false): any {
     if (!values) {
       return {};
     }
@@ -18,13 +18,37 @@ export class SecuredSchemaValueValidationService {
     const flattenedSchema = SchemaHelperService.getFlattenedObject(schema);
     const securedKeyArrayPaths = SecuredSchemaValueValidationService.getSecuredKeyPaths(flattenedSchema);
     if (securedKeyArrayPaths.length) {
-      return SecuredSchemaValueValidationService.getNonSecuredValuesFromObject(securedKeyArrayPaths, '', values, {});
+      return SecuredSchemaValueValidationService.getNonSecuredValuesFromObject(
+        securedKeyArrayPaths.map(path => SecuredSchemaValueValidationService.convertXOfKeys(path)), '', values, returnNullForSecuredValues, {});
     } else {
       return values;
     }
   }
 
-  private static getNonSecuredValuesFromObject(securedKeyPaths: string[], parentPath: string, values: any, result: any): any {
+  private static convertXOfKeys(key: string): string {
+    const keySegments = key.split('.');
+    const keySegmentsConverted = keySegments.slice();
+    let lastGeneralXOfSegmentIdx;
+
+    // convert xOf segments
+    const xOfKeys = Object.values(XOfKeys);
+    keySegments.forEach((segment: string, idx: number) => {
+      xOfKeys.forEach(xOfKey => {
+        if (segment.includes(xOfKey)) {
+          lastGeneralXOfSegmentIdx = xOfKeys.reduce((greatestIdx: number, currentXOfKey: string) => {
+            const lastIdx = SchemaHelperService.getLastIndexOfXOfSegment(keySegments, currentXOfKey);
+            return lastIdx > greatestIdx ? lastIdx : greatestIdx;
+          }, 0);
+
+          keySegmentsConverted.splice(idx, 1);
+        }
+      });
+    });
+
+    return keySegmentsConverted.join('.');
+  }
+
+  private static getNonSecuredValuesFromObject(securedKeyPaths: string[], parentPath: string, values: any, returnNullForSecuredValues: boolean, result: any): any {
     Object.keys(values)
       .forEach(key => {
         const currentPath = !!parentPath ? `${parentPath}.${key}` : key;
@@ -34,7 +58,13 @@ export class SecuredSchemaValueValidationService {
           if (Array.isArray(child) || typeof child !== SecuredSchemaValueValidationService.OBJECT_KEY) { // the child is not an object & is a property
             result[ key ] = child;
           } else {
-            result[ key ] = SecuredSchemaValueValidationService.getNonSecuredValuesFromObject(securedKeyPaths, currentPath, child, {});
+            result[ key ] = SecuredSchemaValueValidationService.getNonSecuredValuesFromObject(securedKeyPaths, currentPath, child, returnNullForSecuredValues, {});
+          }
+        } else if (returnNullForSecuredValues) {
+          if (Array.isArray(child) || typeof child !== SecuredSchemaValueValidationService.OBJECT_KEY) { // the child is not an object & is a property
+            result[ key ] = null;
+          } else {
+            result[ key ] = SecuredSchemaValueValidationService.getNonSecuredValuesFromObject(securedKeyPaths, currentPath, child, returnNullForSecuredValues, {});
           }
         }
       });

--- a/projects/jsf/package.json
+++ b/projects/jsf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleo/ngx-json-schema-form",
-  "version": "4.0.0",
+  "version": "4.0.1`",
   "repository": {
     "type": "git",
     "url": "https://github.com/cleo/ngx-json-schema-form"


### PR DESCRIPTION
## Description
Secured fields within a oneOf should not be returned. Refactored some private methods out of RequiredSchemaValueValidationService into SchemaHelperService.

## Breaking Changes
None

## 3rd Party Dependency Changes
None

## Internal Tracking Number
None

## PR Checklist
_All items should be done and checked before merging._
- [x] **Title:** Provide a very brief, general summary.
- [x] **Details:** Fill out the _Description_, _Breaking Changes_, _3rd Party Dependency Changes_, and _Internal Tracking Number_ sections. If there's nothing for a given section, write "None".
- [x] **Labels:** Add one or more labels.
- [x] **Run Unit Tests:** Locally run the Karma unit tests for this project before merging this PR.
- [x] **Run Lint:** Lint the project before merging this PR.
- [x] **Changelog:** If any code change in this PR will run in production, add an entry to the "Unreleased" section of the `CHANGELOG.md` file.
- [ ] **Update the Wiki:** Update the wiki with the changes for the JSF components.
