### PR TITLE
D-CD-10248

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file. The changes are grouped by the date (ISO-8601) and the package version they have been added to. The `Unreleased` section keeps track of upcoming changes.
 
+## [4.1.5] (2022-09-02)
+### Bug fixes
+- Changed URI validation to be compliant with RFC-3986 
+
 ## [4.1.4] (2022-08-03)
 ### Bug fixes
 - Modified URI text format to only allow valid URI characters, and for additional URI validation to run during the JSF BE validation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6350,9 +6350,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "dev": true,
       "optional": true
     },
@@ -7463,6 +7463,11 @@
       "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
+    },
+    "is.uri": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is.uri/-/is.uri-1.0.0.tgz",
+      "integrity": "sha512-qYwIPmz+u352kvwchp2hNAnTBlm88Gjl55KHsrrDcMHjNcNFxO4QHQEyyKhm5WJ2+uu6ExYpgHPyF0A3BE4hmQ=="
     },
     "isarray": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@angular/router": "9.0.6",
     "ajv": "6.12.2",
     "bootstrap-sass": "3.3.7",
+    "is.uri": "1.0.0",
     "rxjs": "6.5.4",
     "tslib": "1.11.0",
     "zone.js": "0.10.2"

--- a/projects/jsf-validation/package-lock.json
+++ b/projects/jsf-validation/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@cleo/ngx-json-schema-form-validation",
-  "version": "3.0.1",
+  "version": "4.1.5",
   "lockfileVersion": 1
 }

--- a/projects/jsf-validation/package.json
+++ b/projects/jsf-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleo/ngx-json-schema-form-validation",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "peerDependencies": {},
   "repository": {
     "type": "git",

--- a/projects/jsf-validation/src/lib/schema-validation.service.spec.ts
+++ b/projects/jsf-validation/src/lib/schema-validation.service.spec.ts
@@ -99,7 +99,7 @@ describe('SchemaValidationService', () => {
   });
 
   describe('validate()', () => {
-    it('should validate uri format, and at different depths', () => {
+    it('back end validation should validate uri format, and at different depths', () => {
       let err: JSFErrorObject[] = [];
 
       let uriSchema: any = {
@@ -137,6 +137,36 @@ describe('SchemaValidationService', () => {
       expect(err[0].errorObject.schemaPath).toBe('properties.url.format');
       err = SchemaValidationService.validate(uriSchema, {url: 'https://test.com'});
       expect(err).toBe(null);
+
+      const urls: [string, boolean][] = [
+        ['test.com', false],
+        ['https://test.com', true],
+        ['https://test.com:4200', true],
+        ['ftp://test.com', true],
+        ['http://test.com?query=testquery', true],
+        ['http://test-hyphen.com', true],
+        ['http://test.com', true],
+        ['http://test.co', true],
+        ['test.com/🤔', false],
+        ['http://test.com/🤔', false],
+        ['http://test.com/', true],
+        ['test.com/text\u0002.com', false],
+        ['http://test.com/text\u0002.com', false],
+        ['http://test.com/textu0002.com', true],
+        ['http://test.c', false],
+        ['test', false],
+        ['http://test .com', false],
+        ['https//test.com', false],
+        ['http://i-comms.truecommerce.net:42000AS2/F30510A3CH', false],
+        ['http://i-comms.truecommerce.net:42000/AS2/F30510A3CH', true]
+      ];
+
+      for (const testSet of urls) {
+        const url = testSet[0];
+        const expectedValidity = testSet[1];
+        let err = SchemaValidationService.validate(uriSchema, {url: url});
+        expect(err == null).toBe(expectedValidity, `url: ${url} expectedValidity: ${expectedValidity}`);
+      }
     });
 
     it('should return an array of errors when missing required properties', () => {

--- a/projects/jsf-validation/src/lib/schema-validation.service.ts
+++ b/projects/jsf-validation/src/lib/schema-validation.service.ts
@@ -1,9 +1,9 @@
 import Ajv, { ErrorObject } from 'ajv';
 import { get } from 'lodash';
 import { SchemaHelperService } from './schema-helper.service';
+import * as isURI from 'is.uri';
 
-//same as the one in 'projects/jsf/src/lib/validator.service', cannot be imported since they are different projects;
-const URI_REGEX = /^((http[s]?|ftp):\/\/)?\/?([^\/\.]+\.)*?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{2,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/; 
+export const URI_VALID_CHARS_REGEX = /^[A-Za-z0-9\-._~!$&'()*+,;=:@\/?]+$/
 
 /**
  * Schema validation using Another JSON Validator (AJV)
@@ -94,7 +94,7 @@ export class SchemaValidationService {
       if (originalKey.endsWith('.format') && flatSchema[originalKey] === 'uri') {
         const key = SchemaHelperService.formatKeyPath(originalKey);
         const uriValue = get(values, key.substring(0, key.lastIndexOf('.')));
-        if (!URI_REGEX.test(uriValue)) {
+        if (!this.isUriValid(uriValue)) {
           return {
             errorObject: {
               keyword: 'format',
@@ -110,6 +110,19 @@ export class SchemaValidationService {
     }
 
     return null;
+  }
+
+  private static isUriValid(uri: string): boolean {
+    if (!URI_VALID_CHARS_REGEX.test(uri)) {
+      return false
+    }
+
+    let isValid = isURI(uri);
+    //if invalid, try adding 'https://' (allow scheme to be missing)
+    if (!isValid) {
+      isValid = isURI('https://' + uri);
+    }
+    return isValid;
   }
 }
 

--- a/projects/jsf/package-lock.json
+++ b/projects/jsf/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "jsf",
-  "version": "1.0.0",
+  "name": "@cleo/ngx-json-schema-form",
+  "version": "4.1.5",
   "lockfileVersion": 1
 }

--- a/projects/jsf/package.json
+++ b/projects/jsf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleo/ngx-json-schema-form",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/cleo/ngx-json-schema-form"

--- a/projects/jsf/src/lib/form-content/form-controls/form-control-base.ts
+++ b/projects/jsf/src/lib/form-content/form-controls/form-control-base.ts
@@ -3,7 +3,7 @@ import { FormControl, ValidationErrors } from '@angular/forms';
 
 import { FormDataItem } from '../../models/form-data-item';
 import { StringDataItem } from '../../models/string-data-item';
-import { EMAIL_REGEX, URI_REGEX, ValidatorService } from '../../validator.service';
+import { EMAIL_REGEX, ValidatorService } from '../../validator.service';
 import { ContentBaseComponent } from '../content-base.component';
 
 @Directive()
@@ -31,7 +31,7 @@ export class FormControlBase extends ContentBaseComponent implements OnInit {
       return `Please enter a list of valid emails separated by \"${(formItem as StringDataItem).validationSettings.listDelimiter}\"
       Invalid emails:
       ${errors.invalidEmails.join(', ')}`;
-    } else if (hasRequiredPattern && errors.pattern.requiredPattern.toString() === URI_REGEX.toString()) {
+    } else if (errors.invalidUri) {
       return 'Please enter a valid url.';
     } else if (hasRequiredPattern) {
       return `Please enter a valid value.`;

--- a/projects/jsf/src/lib/validator.service.spec.ts
+++ b/projects/jsf/src/lib/validator.service.spec.ts
@@ -2,7 +2,7 @@ import { FormControl, ValidatorFn, Validators } from '@angular/forms';
 import { FormDataItem, FormDataItemType } from './models/form-data-item';
 import { IntegerDataItem, IntegerRangeOptions } from './models/integer-data-item';
 import { StringDataItem, StringFormat, StringLengthOptions } from './models/string-data-item';
-import { URI_REGEX, ValidatorService } from './validator.service';
+import { ValidatorService } from './validator.service';
 import Spy = jasmine.Spy;
 
 describe('ValidatorService', () => {
@@ -238,7 +238,7 @@ describe('ValidatorService', () => {
             expect(validatorFn(control)).toBeNull();
           });
 
-          it('it correctly validates uris against the uri format regex', () => {
+          it('front end correctly validates uris against the uri validator', () => {
             const urls: [string, boolean][] = [
               ['test.com', true],
               ['https://test.com', true],
@@ -250,16 +250,21 @@ describe('ValidatorService', () => {
               ['http://test.co', true],
               ['test.com/🤔', false],
               ['test.com/text\u0002.com', false],
+              ['http://test.com/text\u0002.com', false],
+              ['http://test.com/textu0002.com', true],
               ['http://test.c', false],
               ['test', false],
               ['http://test .com', false],
-              ['https//test.com', false]
+              ['https//test.com', false],
+              ['http://i-comms.truecommerce.net:42000AS2/F30510A3CH', false],
+              ['http://i-comms.truecommerce.net:42000/AS2/F30510A3CH', true]
             ];
 
             for (const testSet of urls) {
               const url = testSet[0];
               const expectedValidity = testSet[1];
-              expect(URI_REGEX.test(url)).toBe(expectedValidity, `url: ${url} expectedValidity: ${expectedValidity}`);
+              control.setValue(url);
+              expect(validatorFn(control) === null).toBe(expectedValidity, `url: ${url} expectedValidity: ${expectedValidity}`);
             }
           });
         });


### PR DESCRIPTION
## Description
Instead of using regex to validate URIs, this PR adds the use of https://www.npmjs.com/package/is.uri to validate uris. 

The `is.uri` package is the only package I was able to find that would be able to flag theses URIs as invalid:
- `http://i-comms.truecommerce.net:42000AS2/F30510A3CH`
- `https://http//test.com`
- `https://test.c`

## Breaking Changes
None

## 3rd Party Dependency Changes
Added `"is.uri": "1.0.0"`

## Internal Tracking Number
[D-CD-10248](https://cleo-jira.atlassian.net/browse/CD-10248)

## PR Checklist
_All items should be done and checked before merging._
- [ ] **Title:** Provide a very brief, general summary.
- [ ] **Details:** Fill out the _Description_, _Breaking Changes_, _3rd Party Dependency Changes_, and _Internal Tracking Number_ sections. If there's nothing for a given section, write "None".
- [ ] **Labels:** Add one or more labels.
- [ ] **Run Unit Tests:** Locally run the Karma unit tests for this project before merging this PR.
- [ ] **Run Lint:** Lint the project before merging this PR.
- [ ] **Changelog:** If any code change in this PR will run in production, add an entry to the "Unreleased" section of the `CHANGELOG.md` file.
- [ ] **Update the Wiki:** Update the wiki with the changes for the JSF components.
