### PR TITLE
D-CD-10248 fix long url failing validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file. The changes are grouped by the date (ISO-8601) and the package version they have been added to. The `Unreleased` section keeps track of upcoming changes.
 
+## [4.1.6] (2022-10-31)
+### Bug fixes
+- Fixed URI validation regex timing out with long URIs.
+
 ## [4.1.5] (2022-09-02)
 ### Bug fixes
 - Changed URI validation to be compliant with RFC-3986 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7464,11 +7464,6 @@
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
     },
-    "is.uri": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is.uri/-/is.uri-1.0.0.tgz",
-      "integrity": "sha512-qYwIPmz+u352kvwchp2hNAnTBlm88Gjl55KHsrrDcMHjNcNFxO4QHQEyyKhm5WJ2+uu6ExYpgHPyF0A3BE4hmQ=="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@angular/router": "9.0.6",
     "ajv": "6.12.2",
     "bootstrap-sass": "3.3.7",
-    "is.uri": "1.0.0",
     "rxjs": "6.5.4",
     "tslib": "1.11.0",
     "zone.js": "0.10.2"

--- a/projects/jsf-validation/package-lock.json
+++ b/projects/jsf-validation/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@cleo/ngx-json-schema-form-validation",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "lockfileVersion": 1
 }

--- a/projects/jsf-validation/package.json
+++ b/projects/jsf-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleo/ngx-json-schema-form-validation",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "peerDependencies": {},
   "repository": {
     "type": "git",

--- a/projects/jsf-validation/src/lib/schema-validation.service.ts
+++ b/projects/jsf-validation/src/lib/schema-validation.service.ts
@@ -119,6 +119,7 @@ export class SchemaValidationService {
     }
 
     let isValid = URI_REGEX.test(uri);
+    //if invalid, try adding 'https://' (allow scheme to be missing)
     if (!isValid) {
       isValid = URI_REGEX.test(`https://${uri}`);
     }

--- a/projects/jsf-validation/src/lib/schema-validation.service.ts
+++ b/projects/jsf-validation/src/lib/schema-validation.service.ts
@@ -1,11 +1,10 @@
 import Ajv, { ErrorObject } from 'ajv';
-import { get } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import { SchemaHelperService } from './schema-helper.service';
 
-import * as isURI_ from 'is.uri';
-const isURI = isURI_;
-
 export const URI_VALID_CHARS_REGEX = /^[A-Za-z0-9\-._~!$&'()*+,;=:@\/?]+$/;
+//https://mathiasbynens.be/demo/url-regex
+export const URI_REGEX = new RegExp(/^(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$/, 'i');
 
 /**
  * Schema validation using Another JSON Validator (AJV)
@@ -115,14 +114,13 @@ export class SchemaValidationService {
   }
 
   private static isUriValid(uri: string): boolean {
-    if (!URI_VALID_CHARS_REGEX.test(uri)) {
+    if (isEmpty(uri) || !URI_VALID_CHARS_REGEX.test(uri)) {
       return false;
     }
 
-    let isValid = isURI(uri);
-    //if invalid, try adding 'https://' (allow scheme to be missing)
+    let isValid = URI_REGEX.test(uri);
     if (!isValid) {
-      isValid = isURI(`https://${uri}`);
+      isValid = URI_REGEX.test(`https://${uri}`);
     }
     return isValid;
   }

--- a/projects/jsf/package-lock.json
+++ b/projects/jsf/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@cleo/ngx-json-schema-form",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "lockfileVersion": 1
 }

--- a/projects/jsf/package.json
+++ b/projects/jsf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleo/ngx-json-schema-form",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/cleo/ngx-json-schema-form"

--- a/projects/jsf/src/lib/validator.service.spec.ts
+++ b/projects/jsf/src/lib/validator.service.spec.ts
@@ -257,7 +257,8 @@ describe('ValidatorService', () => {
               ['http://test .com', false],
               ['https//test.com', false],
               ['http://i-comms.truecommerce.net:42000AS2/F30510A3CH', false],
-              ['http://i-comms.truecommerce.net:42000/AS2/F30510A3CH', true]
+              ['http://i-comms.truecommerce.net:42000/AS2/F30510A3CH', true],
+              ['http://i-comms.truecommerce.net:42000/AS2/F30510A3CH1234567890123456789012345678901234567890', true]
             ];
 
             for (const testSet of urls) {

--- a/projects/jsf/src/lib/validator.service.ts
+++ b/projects/jsf/src/lib/validator.service.ts
@@ -90,6 +90,7 @@ export class ValidatorService {
       }
 
       let isValid = URI_REGEX.test(uri);
+      //if invalid, try adding 'https://' (allow scheme to be missing)
       if (!isValid) {
         isValid = URI_REGEX.test(`https://${uri}`);
       }

--- a/projects/jsf/src/lib/validator.service.ts
+++ b/projects/jsf/src/lib/validator.service.ts
@@ -1,16 +1,17 @@
 import { Injectable } from '@angular/core';
 import { AbstractControl, ValidatorFn, Validators } from '@angular/forms';
+import { isEmpty } from 'lodash';
 import { EnumDataItem } from './models/enum-data-item';
 import { FormDataItem, FormDataItemType } from './models/form-data-item';
 import { IntegerDataItem } from './models/integer-data-item';
 import { StringDataItem, StringFormat } from './models/string-data-item';
 
-import * as isURI_ from 'is.uri';
-const isURI = isURI_;
-
 // http://stackoverflow.com/a/46181/1447823 chromium's regex for testing for email
 export const EMAIL_REGEX = /^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
-export const URI_VALID_CHARS_REGEX = /^[A-Za-z0-9\-._~!$&'()*+,;=:@\/?]+$/;
+export const URI_VALID_CHARS_REGEX = new RegExp(/^[A-Za-z0-9\-._~!$&'()*+,;=:@\/?]+$/);
+
+//https://mathiasbynens.be/demo/url-regex
+export const URI_REGEX = new RegExp(/^(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$/, 'i');
 
 @Injectable()
 export class ValidatorService {
@@ -84,14 +85,13 @@ export class ValidatorService {
   }
 
   private isUriValid(uri: string): boolean {
-      if (!URI_VALID_CHARS_REGEX.test(uri)) {
+      if (isEmpty(uri) || !URI_VALID_CHARS_REGEX.test(uri)) {
         return false;
       }
 
-      let isValid = isURI(uri);
-      //if invalid, try adding 'https://' (allow scheme to be missing)
+      let isValid = URI_REGEX.test(uri);
       if (!isValid) {
-        isValid = isURI(`https://${uri}`);
+        isValid = URI_REGEX.test(`https://${uri}`);
       }
       return isValid;
   }


### PR DESCRIPTION
## Description
The `is.uri` package's regex would run too long if the # of characters > 28.
I found  a new regex that does what we want.

## Breaking Changes
None

## 3rd Party Dependency Changes
Removed `is.uri` package.

## Internal Tracking Number
[CD-10248](https://cleo-jira.atlassian.net/browse/CD-10248)

## PR Checklist
_All items should be done and checked before merging._
- [x] **Title:** Provide a very brief, general summary.
- [x] **Details:** Fill out the _Description_, _Breaking Changes_, _3rd Party Dependency Changes_, and _Internal Tracking Number_ sections. If there's nothing for a given section, write "None".
- [x] **Labels:** Add one or more labels.
- [x] **Run Unit Tests:** Locally run the Karma unit tests for this project before merging this PR.
- [x] **Run Lint:** Lint the project before merging this PR.
- [x] **Changelog:** If any code change in this PR will run in production, add an entry to the "Unreleased" section of the `CHANGELOG.md` file.
- [ ] **Update the Wiki:** Update the wiki with the changes for the JSF components.
