### PR TITLE
6.0.2 fix secured text inputs to always be string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file. The changes are grouped by the date (ISO-8601) and the package version they have been added to. The `Unreleased` section keeps track of upcoming changes.
 
+## [6.0.2] (2023-11-14)
+### Bug Fix
+- Fix Secured Text Input values to always be treated as a string
+
 ## [6.0.1] (2023-07-20)
 ### Bug Fix
 - Target ES2015

--- a/projects/jsf-validation/package.json
+++ b/projects/jsf-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleo/ngx-json-schema-form-validation",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "peerDependencies": {},
   "dependencies": {
     "tslib": "^2.0.0"

--- a/projects/jsf/package.json
+++ b/projects/jsf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleo/ngx-json-schema-form",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/cleo/ngx-json-schema-form"

--- a/projects/jsf/src/lib/form-content/form-controls/secured-text/secured-text.component.ts
+++ b/projects/jsf/src/lib/form-content/form-controls/secured-text/secured-text.component.ts
@@ -63,9 +63,5 @@ export class SecuredTextComponent extends FormControlBase {
 
     // null indicates the input has been cleared and that a value should be returned.
     this.formItem.disabledState.isDisabledOnSubmit = this.isEdit && (value === undefined || value === '');
-
-    try {
-      this.formControl.setValue(JSON.parse(this.formControl.value));
-    } catch { }
   }
 }


### PR DESCRIPTION
## Description
Fixed Secured Text Input fields setting their form value as an integer if all integer values were entered.

## Breaking Changes
None

## 3rd Party Dependency Changes
None

## Internal Tracking Number
[CD-18073](https://cleo-jira.atlassian.net/browse/CD-18073)

## PR Checklist
_All items should be done and checked before merging._
- [ ] **Title:** Provide a very brief, general summary.
- [ ] **Details:** Fill out the _Description_, _Breaking Changes_, _3rd Party Dependency Changes_, and _Internal Tracking Number_ sections. If there's nothing for a given section, write "None".
- [ ] **Labels:** Add one or more labels.
- [ ] **Run Unit Tests:** Locally run the Karma unit tests for this project before merging this PR.
- [ ] **Run Lint:** Lint the project before merging this PR.
- [ ] **Changelog:** If any code change in this PR will run in production, add an entry to the "Unreleased" section of the `CHANGELOG.md` file.
- [ ] **Update the Wiki:** Update the wiki with the changes for the JSF components.
