### PR TITLE
7.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file. The changes are grouped by the date (ISO-8601) and the package version they have been added to. The `Unreleased` section keeps track of upcoming changes.
 
+## [7.0.4] (2026-05-20)
+### Bug Fix
+- Fixed required asterisk (*) not displaying on secured (password) fields in edit mode.
+
 ## [7.0.3] (2026-05-12)
 ### Bug Fix
 - Fixed `TabsComponent` not updating when tabs are dynamically added or removed, causing stale `selectedTab` reference and broken tab switching

--- a/projects/jsf-validation/package.json
+++ b/projects/jsf-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleo/ngx-json-schema-form-validation",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "peerDependencies": {},
   "dependencies": {
     "ajv": "^6.12.6",

--- a/projects/jsf/package.json
+++ b/projects/jsf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleo/ngx-json-schema-form",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/cleo/ngx-json-schema-form"

--- a/projects/jsf/src/lib/form-content/form-controls/label/label.component.ts
+++ b/projects/jsf/src/lib/form-content/form-controls/label/label.component.ts
@@ -1,6 +1,7 @@
 import { Component, input } from '@angular/core';
 import { EnumDataItem, OptionDisplayType } from '../../../models/enum-data-item';
 import { FormDataItem, FormDataItemType } from '../../../models/form-data-item';
+import { SecuredStringDataItem } from '../../../models/secured-string-data-item';
 
 
 @Component({
@@ -42,6 +43,6 @@ export class LabelComponent {
 
   isRequired(): boolean {
     const item = this.formItem();
-    return item?.required || item?.type === FormDataItemType.Enum;
+    return item?.required || (item instanceof SecuredStringDataItem && item.wasRequired) || item?.type === FormDataItemType.Enum;
   }
 }


### PR DESCRIPTION
## Description
This pull request addresses a bug where the required asterisk (*) was not displaying on secured (password) fields in edit mode. The fix ensures that required indicators now correctly appear for secured fields, and the package versions have been incremented accordingly.

Bug Fix:

* Updated the `LabelComponent`'s `isRequired` method to correctly show the required asterisk on secured (password) fields by checking if the item is an instance of `SecuredStringDataItem` and if it was required.

Version Updates:

* Bumped the version of `@cleo/ngx-json-schema-form` to `7.0.4` in `projects/jsf/package.json`.
* Bumped the version of `@cleo/ngx-json-schema-form-validation` to `7.0.4` in `projects/jsf-validation/package.json`.

Documentation:

* Added a changelog entry for version `7.0.4`, detailing the bug fix for the required asterisk on secured fields.
## Breaking Changes
None

## 3rd Party Dependency Changes
None

## Internal Tracking Number
https://cleo-jira.atlassian.net/browse/CD-34519

## PR Checklist
_All items should be done and checked before merging._
- [ ] **Title:** Provide a very brief, general summary.
- [ ] **Details:** Fill out the _Description_, _Breaking Changes_, _3rd Party Dependency Changes_, and _Internal Tracking Number_ sections. If there's nothing for a given section, write "None".
- [ ] **Labels:** Add one or more labels.
- [ ] **Run Unit Tests:** Locally run the Karma unit tests for this project before merging this PR.
- [ ] **Run Lint:** Lint the project before merging this PR.
- [ ] **Changelog:** If any code change in this PR will run in production, add an entry to the "Unreleased" section of the `CHANGELOG.md` file.
- [ ] **Update the Wiki:** Update the wiki with the changes for the JSF components.
