### PR TITLE
7.0.5

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to JSON Schema Form
+
+This guide describes, at a high level, what a typical change to the JSF repo should look
+like. It captures the conventions this codebase follows so that changes stay consistent
+and ship cleanly to consumers (notably the **crowsnest** client).
+
+## Repo layout
+
+This is an Angular workspace with three projects:
+
+| Project | Path | Purpose |
+| --- | --- | --- |
+| `jsf` | `projects/jsf` | The published front-end library (`@cleo/ngx-json-schema-form`). Renders a form from a JSON Schema object. |
+| `jsf-validation` | `projects/jsf-validation` | The published back-end validation library (`@cleo/ngx-json-schema-form-validation`). |
+| `jsf-launcher` | `projects/jsf-launcher` | A local demo/test harness app. Not published. |
+
+## Tech baseline
+
+- Angular 20, TypeScript 5.8, Node 22.x, ag-grid 35.
+- Standalone components only — no NgModules.
+- `@Input()`/`@Output()` are migrated to signals: use `input()`, `input.required()`, and
+  `output()`.
+- Use `inject()` for dependency injection, not constructor parameters.
+- Use `@if` / `@for` control flow in templates, not `*ngIf` / `*ngFor`.
+- React to input changes with `effect()`, not `ngOnChanges`.
+- Components default to `ChangeDetectionStrategy.OnPush` — if you build/mutate state
+  asynchronously (e.g. inside an `effect` reacting to a signal input), remember to call
+  `ChangeDetectorRef.markForCheck()` so the view re-renders.
+
+## Anatomy of a typical change
+
+### 1. Library code (`projects/jsf/src/lib`)
+- Make the focused change. Keep edits minimal and consistent with the surrounding code.
+- Maintain **ag-grid backward compatibility** (see `.github/copilot-instructions.md`).
+
+### 2. Public API (`projects/jsf/src/public_api.ts`)
+- If you add a new public type, service, or component, export it here.
+
+### 3. Tests (`*.spec.ts`)
+- Add or update unit tests next to the file you changed.
+- Cover the new behavior and its edge cases (e.g. an output should emit at the right time,
+  and in the boundary cases — not just the happy path).
+
+### 4. Demo app (`projects/jsf-launcher`)
+- Wire up new inputs/outputs in `app.component.html` / `app.component.ts` so the behavior
+  can be exercised locally. This is optional but preferred.
+
+### 5. Docs
+- Update `projects/jsf/README.md` (consumer-facing docs) when you add or change a public
+  input/output/method. Follow the existing style.
+- Add a `CHANGELOG.md` entry under a new version heading. Group entries under
+  `### Bug Fix`, `### Enhancement`, or `### Breaking Changes`.
+
+### 6. Version bump
+- Bump the version in **both** `projects/jsf/package.json` and
+  `projects/jsf-validation/package.json` together, following semver
+  (e.g. `7.0.4` → `7.0.5`). The two libraries are versioned in lockstep.
+
+## ag-grid backward compatibility
+
+The **crowsnest** consumer still uses ag-grid 28, so always provide fallbacks for ag-grid
+APIs that moved between versions. See `.github/copilot-instructions.md` for the exact
+fallback patterns and selection-config rules.
+
+## Before you finish
+
+Run the unit tests and lint from the repo root:
+
+```bash
+npm run test            # jsf unit tests (Karma)
+npm run test-validation # jsf-validation tests
+npm run lint
+```
+
+For a quick headless run of just the library tests:
+
+```bash
+npx ng test jsf --watch=false --browsers=ChromeHeadless
+```
+
+## Testing in a consuming app
+
+To build, pack, and install the library into **crowsnest** for local verification, follow
+the build/pack/install steps in `.github/copilot-instructions.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file. The changes are grouped by the date (ISO-8601) and the package version they have been added to. The `Unreleased` section keeps track of upcoming changes.
 
+## [7.0.5] (2026-06-12)
+### Bug Fix
+- Fixed `JSFComponent` rendering a blank form intermittently when `schemaData` is provided asynchronously. The form structure was built after the last change-detection pass, but because the component is `OnPush` it never re-rendered, leaving the child `jsf-form-content` with an empty `[formItems]` binding. `JSFComponent` now calls `ChangeDetectorRef.markForCheck()` after building the form on every `schemaData` change.
+### Enhancement
+- Added `formReady` output event to `JSFComponent` that emits once the form's internal structure (FormGroup, controls, and data items) has been built from the current `schemaData`. It emits even when `getFormValues()` is empty (e.g. all-hidden or template-only schemas), and emits again whenever `schemaData` changes and the form is rebuilt. Consumers can use this instead of polling `getFormValues()` to detect readiness.
+
 ## [7.0.4] (2026-05-20)
 ### Bug Fix
 - Fixed required asterisk (*) not displaying on secured (password) fields in edit mode.

--- a/projects/jsf-launcher/src/app/app.component.html
+++ b/projects/jsf-launcher/src/app/app.component.html
@@ -6,8 +6,15 @@
   (formHeightChange)="emitTotalHeight($event)"
   (buttonEvent)="buttonEvent($event)"
   (templateEvent)="templateEvent($event)"
-  (tabChange)="activeTab = $event">
+  (tabChange)="activeTab = $event"
+  (formReady)="onFormReady()">
 </jsf-component>
+
+@if (formReadyCount) {
+  <div class="active-tab-indicator">
+    formReady fired: <strong>{{ formReadyCount }}</strong> time(s)
+  </div>
+}
 
 @if (activeTab) {
   <div class="active-tab-indicator">

--- a/projects/jsf-launcher/src/app/app.component.ts
+++ b/projects/jsf-launcher/src/app/app.component.ts
@@ -39,6 +39,7 @@ export class AppComponent implements OnInit, AfterViewInit {
 
   templateInitEvent: TemplateEvent;
   activeTab: string;
+  formReadyCount = 0;
 
   ngOnInit(): void {
     this.setSchemas();
@@ -95,6 +96,11 @@ export class AppComponent implements OnInit, AfterViewInit {
 
   buttonEvent(event: any): void {
     //console.log('in buttonEvent in app.component.ts: \n', event);
+  }
+
+  onFormReady(): void {
+    this.formReadyCount++;
+    // console.log('formReady fired', this.formReadyCount);
   }
 
   templateEvent(event: any): void {

--- a/projects/jsf-validation/package.json
+++ b/projects/jsf-validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleo/ngx-json-schema-form-validation",
-  "version": "7.0.4",
+  "version": "7.0.5",
   "peerDependencies": {},
   "dependencies": {
     "ajv": "^6.12.6",

--- a/projects/jsf/README.md
+++ b/projects/jsf/README.md
@@ -38,6 +38,7 @@ export class ExampleComponent { }
    - [Optional] Listen to the `buttonEvent` event to handle button clicks defined in the schema. The event emits a `JSFEventButton` with the button's key and targets.
    - [Optional] Listen to the `templateEvent` event to handle events from custom templates. The event emits a `JSFTemplateEvent` with the template's key and target paths.
    - [Optional] Listen to the `tabChange` event to be notified when the active tab changes. The event emits the tab's property key from the JSON schema.
+   - [Optional] Listen to the `formReady` event to be notified once the form's internal structure (FormGroup, controls, and data items) has been built from the current `schemaData`. This is the reliable way to know the form is ready to be read (e.g. via `getFormValues()` or `formGroup.get(...)`), and it emits even when the form produces no values (e.g. an all-hidden or template-only schema). It emits again whenever `schemaData` changes and the form is rebuilt.
 
 ```typescript
 import { Component, ViewChild, signal } from '@angular/core';
@@ -77,6 +78,10 @@ export class ExampleComponent {
   // this event emits the key of the active tab whenever it changes
   onTabChange(tabKey: string): void { }
 
+  // this event is emitted once the form structure has been built from the schemaData,
+  // and again whenever a new schema is provided and the form is rebuilt
+  onFormReady(): void { }
+
   getJSFFormValues(): void {
     const jsonData = this.schemaFormComponent.getFormValues();
   }
@@ -93,7 +98,8 @@ export class ExampleComponent {
    (formHeightChange)="onFormHeightChange($event)"
    (buttonEvent)="onButtonEvent($event)"
    (templateEvent)="onTemplateEvent($event)"
-   (tabChange)="onTabChange($event)">
+   (tabChange)="onTabChange($event)"
+   (formReady)="onFormReady()">
   </jsf-component>
 ```
 

--- a/projects/jsf/package.json
+++ b/projects/jsf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleo/ngx-json-schema-form",
-  "version": "7.0.4",
+  "version": "7.0.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/cleo/ngx-json-schema-form"

--- a/projects/jsf/src/lib/jsf.component.spec.ts
+++ b/projects/jsf/src/lib/jsf.component.spec.ts
@@ -1,0 +1,102 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { JSFComponent } from './jsf.component';
+import { JSFConfig } from './jsf-config';
+import { JSFJsonSchema } from './jsf-json-schema';
+import { JSFSchemaData } from './jsf-schema-data';
+
+describe('JSFComponent', () => {
+  const config: JSFConfig = {
+    enableCollapsibleSections: false,
+    showSectionDivider: true,
+    expandOuterSectionsByDefault: true
+  };
+
+  const schemaWithValues: JSFJsonSchema = {
+    version: '2.0.0',
+    type: 'object',
+    properties: {
+      name: { type: 'string', name: 'Name' }
+    }
+  };
+
+  // A schema that produces no value-producing fields, so getFormValues() is empty.
+  const emptySchema: JSFJsonSchema = {
+    version: '2.0.0',
+    type: 'object',
+    properties: {}
+  };
+
+  let fixture: ComponentFixture<JSFComponent>;
+  let component: JSFComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [JSFComponent]
+    });
+
+    fixture = TestBed.createComponent(JSFComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('config', config);
+  });
+
+  it('should emit formReady once after a schema is provided', () => {
+    const formReadySpy = jasmine.createSpy('formReady');
+    component.formReady.subscribe(formReadySpy);
+
+    fixture.componentRef.setInput('schemaData', new JSFSchemaData(schemaWithValues, {}));
+    fixture.detectChanges();
+
+    expect(formReadySpy).toHaveBeenCalledTimes(1);
+    expect(Object.keys(component.getFormValues()).length).toBeGreaterThan(0);
+  });
+
+  it('should emit formReady even when getFormValues() is empty', () => {
+    const formReadySpy = jasmine.createSpy('formReady');
+    component.formReady.subscribe(formReadySpy);
+
+    fixture.componentRef.setInput('schemaData', new JSFSchemaData(emptySchema, {}));
+    fixture.detectChanges();
+
+    expect(formReadySpy).toHaveBeenCalledTimes(1);
+    expect(component.getFormValues()).toEqual({});
+  });
+
+  it('should emit formReady again when schemaData is replaced with a new schema', () => {
+    const formReadySpy = jasmine.createSpy('formReady');
+    component.formReady.subscribe(formReadySpy);
+
+    fixture.componentRef.setInput('schemaData', new JSFSchemaData(emptySchema, {}));
+    fixture.detectChanges();
+    expect(formReadySpy).toHaveBeenCalledTimes(1);
+
+    fixture.componentRef.setInput('schemaData', new JSFSchemaData(schemaWithValues, {}));
+    fixture.detectChanges();
+    expect(formReadySpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should render the form fields after schemaData is provided asynchronously', () => {
+    // No schemaData yet — simulate an async (e.g. HTTP) source.
+    fixture.detectChanges();
+
+    fixture.componentRef.setInput('schemaData', new JSFSchemaData(schemaWithValues, {}));
+    fixture.detectChanges();
+
+    expect(component.formDataItems.length).toBe(1);
+    expect(fixture.nativeElement.querySelectorAll('input').length).toBeGreaterThan(0);
+  });
+
+  it('should mark the view for check on every schemaData change so OnPush re-renders', () => {
+    const cd = (component as unknown as { cd: ChangeDetectorRef }).cd;
+    const markForCheckSpy = spyOn(cd, 'markForCheck').and.callThrough();
+
+    fixture.componentRef.setInput('schemaData', new JSFSchemaData(emptySchema, {}));
+    fixture.detectChanges();
+    expect(markForCheckSpy).toHaveBeenCalledTimes(1);
+
+    fixture.componentRef.setInput('schemaData', new JSFSchemaData(schemaWithValues, {}));
+    fixture.detectChanges();
+    expect(markForCheckSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/projects/jsf/src/lib/jsf.component.ts
+++ b/projects/jsf/src/lib/jsf.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, effect, ElementRef, inject, input, OnInit, output, ViewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, effect, ElementRef, inject, input, OnInit, output, ViewChild } from '@angular/core';
 import { ReactiveFormsModule, UntypedFormGroup } from '@angular/forms';
 
 import { take, tap } from 'rxjs/operators';
@@ -31,6 +31,7 @@ import { XOfEnumDataItem } from './models/xOf-enum-data-item';
 export class JSFComponent extends ComponentLifeCycle implements AfterViewInit, OnInit {
   private formService = inject(FormService);
   private dataItemService = inject(FormDataItemService);
+  private cd = inject(ChangeDetectorRef);
 
   @ViewChild(FormContentComponent, {static: true}) content: FormContentComponent;
   @ViewChild('formRoot', {static: true}) formElement: ElementRef<HTMLFormElement>;
@@ -44,6 +45,7 @@ export class JSFComponent extends ComponentLifeCycle implements AfterViewInit, O
   buttonEvent = output<JSFEventButton>();
   templateEvent = output<JSFTemplateEvent>();
   tabChange = output<string>();
+  formReady = output<void>();
 
   formDataItems: FormDataItem[] = [];
   formGroup: UntypedFormGroup = new UntypedFormGroup({});
@@ -68,6 +70,17 @@ export class JSFComponent extends ComponentLifeCycle implements AfterViewInit, O
       if (this.isEdit && this.formGroup.valid) {
         this.disableSubmit.emit(false);
       }
+
+      // The form was (re)built outside of (or after) the change-detection pass that
+      // processed the schemaData signal. Because this component is OnPush, mark it for
+      // check so the child jsf-form-content re-evaluates its [formItems] binding and the
+      // fields actually render. This runs on every schemaData change.
+      this.cd.markForCheck();
+
+      // The form structure (FormGroup/controls/formDataItems) has now been built from the
+      // current schema and the view has been flagged for re-render. Notify consumers exactly
+      // once per successful build, regardless of whether getFormValues() produces any values.
+      this.formReady.emit();
 
       const statusSubscription = this.formGroup.statusChanges.pipe(
         tap(status => {


### PR DESCRIPTION
## Description
This pull request introduces a bug fix and a new enhancement to the `JSFComponent` in the `@cleo/ngx-json-schema-form` library, along with updates to documentation, tests, and the demo app. The bug fix ensures the form renders correctly when schema data is provided asynchronously, and the enhancement adds a new `formReady` output event to notify consumers when the form is ready. Version numbers and documentation have been updated accordingly.

**Bug Fixes and Enhancements:**

*JSFComponent improvements:*
- Fixed an issue where the form would sometimes render blank when `schemaData` was provided asynchronously by ensuring `ChangeDetectorRef.markForCheck()` is called after building the form on every `schemaData` change, so the view re-renders properly with `OnPush` change detection.
- Added a new `formReady` output event to `JSFComponent` that emits once the form's internal structure is built from the current `schemaData`, and emits again whenever the schema changes and the form is rebuilt. This provides a reliable signal for consumers to know when the form is ready.

*Testing:*
- Added comprehensive unit tests to verify that `formReady` emits at the correct times (including when the schema produces no form values), and that the view is marked for check on every schema change.

*Documentation:*
- Updated `projects/jsf/README.md` to document the new `formReady` event and show example usage. [[1]](diffhunk://#diff-bb3c5ce7b63ae5c986474892da32c2c30dfd4f34d9a7338d17ea2ca5c70cb000R41) [[2]](diffhunk://#diff-bb3c5ce7b63ae5c986474892da32c2c30dfd4f34d9a7338d17ea2ca5c70cb000R81-R84) [[3]](diffhunk://#diff-bb3c5ce7b63ae5c986474892da32c2c30dfd4f34d9a7338d17ea2ca5c70cb000L96-R102)
- Added a new `.github/CONTRIBUTING.md` file detailing repo conventions, tech stack, and contribution workflow.
- Updated `CHANGELOG.md` with entries for the bug fix and enhancement.




## Breaking Changes
None

## 3rd Party Dependency Changes
None
## Internal Tracking Number
https://cleo-jira.atlassian.net/browse/CD-33978

## PR Checklist
_All items should be done and checked before merging._
- [x] **Title:** Provide a very brief, general summary.
- [x] **Details:** Fill out the _Description_, _Breaking Changes_, _3rd Party Dependency Changes_, and _Internal Tracking Number_ sections. If there's nothing for a given section, write "None".
- [x] **Labels:** Add one or more labels.
- [x] **Run Unit Tests:** Locally run the Karma unit tests for this project before merging this PR.
- [x] **Run Lint:** Lint the project before merging this PR.
- [x] **Changelog:** If any code change in this PR will run in production, add an entry to the "Unreleased" section of the `CHANGELOG.md` file.
- [ ] **Update the Wiki:** Update the wiki with the changes for the JSF components.
